### PR TITLE
Add basic Binance trade dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # NewProject
-NewProject
+
+This repository contains a simple dashboard example for viewing cryptocurrency data.
+
+## Dashboard
+
+Open `dashboard.html` in your browser to see a basic Binance trade dashboard. The page displays a table with sample trading pairs and prices. It refreshes data every few seconds using placeholder values.

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Binance Trade Dashboard</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background-color: #f4f4f4;
+        }
+        h1 {
+            text-align: center;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            border: 1px solid #ddd;
+            padding: 8px;
+            text-align: center;
+        }
+        th {
+            background-color: #f2b90f;
+            color: #fff;
+        }
+        #chart {
+            width: 100%;
+            height: 300px;
+            margin-top: 30px;
+            background: #fff;
+            border: 1px solid #ddd;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #999;
+        }
+    </style>
+</head>
+<body>
+    <h1>Binance Trade Dashboard</h1>
+    <table id="ticker-table">
+        <thead>
+            <tr>
+                <th>Pair</th>
+                <th>Price (USDT)</th>
+                <th>Change 24h</th>
+            </tr>
+        </thead>
+        <tbody>
+            <!-- Data will be inserted here by JavaScript -->
+        </tbody>
+    </table>
+
+    <div id="chart">Price chart coming soon...</div>
+
+    <script>
+        const data = [
+            { pair: 'BTCUSDT', price: 64000, change: '+2.5%' },
+            { pair: 'ETHUSDT', price: 3500, change: '-1.2%' },
+            { pair: 'BNBUSDT', price: 500, change: '+0.8%' },
+        ];
+
+        function populateTable() {
+            const tbody = document.querySelector('#ticker-table tbody');
+            tbody.innerHTML = '';
+            data.forEach(row => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${row.pair}</td>
+                    <td>${row.price}</td>
+                    <td>${row.change}</td>
+                `;
+                tbody.appendChild(tr);
+            });
+        }
+
+        // Refresh data every 5 seconds (placeholder)
+        setInterval(() => {
+            // Here you would normally fetch data from Binance API
+            populateTable();
+        }, 5000);
+
+        // Initial load
+        populateTable();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `dashboard.html` showing a placeholder Binance trade table
- update `README.md` with instructions to open the dashboard page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687597d17620832e97b2bf7d444f03d6